### PR TITLE
리뷰 수정 저장 버튼 스펙 완화

### DIFF
--- a/react/1/hw-test/tests/integration/edit-review.spec.ts
+++ b/react/1/hw-test/tests/integration/edit-review.spec.ts
@@ -35,7 +35,7 @@ test('수정 버튼을 누르면 리뷰의 내용을 수정할 수 있다 (수�
   await reviewItem.hover();
   await reviewItem.getByTestId(TEST_ID['리뷰 수정 버튼']).click();
   await reviewItem.getByTestId(TEST_ID['리뷰 수정 인풋']).fill('수정된 리뷰');
-  await page.getByTestId(TEST_ID['리뷰 수정 저장 버튼']).click();
+  await reviewItem.getByTestId(TEST_ID['리뷰 수정 저장 버튼']).click();
   await expect(reviewItem.getByTestId(TEST_ID['리뷰 수정 인풋'])).not.toBeVisible();
   await expect(reviewItem).toContainText('수정된 리뷰');
   await expect(page.getByTestId(TEST_ID['리뷰 목록']).getByTestId(TEST_ID['리뷰'])).toHaveCount(2);


### PR DESCRIPTION
https://wafflestudio2-k6c7167.slack.com/archives/C05P8FYRAQ0/p1696158258036649?thread_ts=1695378554.653679&cid=C05P8FYRAQ0

위 메세지의 2번 케이스를 resolve합니다. 리뷰 수정 저장 버튼이 DOM에 존재하되 보이지만 않게 했을 수 있으므로 완화합니다.